### PR TITLE
Remove path and suffix from appname

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -25,6 +26,9 @@ const (
 // guaranteed). See `App.parse`
 func Parse(a App, appargs []string) (invocation []string, args []string, opts map[string]string, err error) {
 	_, appname := path.Split(appargs[0])
+	// Remove the path and extension of the executable
+	appname = filepath.Base(appname)
+	appname = strings.TrimSuffix(appname, filepath.Ext(appname))
 
 	invocation, argsAndOpts, expArgs, accptOpts := evalCommand(a, appargs[1:])
 	invocation = append([]string{appname}, invocation...)


### PR DESCRIPTION
The path and suffix is now removed from the applications name. Fixes #5.

## Before

![](https://user-images.githubusercontent.com/10981005/117496567-22805b00-af6f-11eb-9d37-fe730100db68.png)

## After

![](https://user-images.githubusercontent.com/10981005/117496594-2ad89600-af6f-11eb-99da-171134155c2b.png)
